### PR TITLE
Smoke test releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,45 +4,43 @@ on:
     branches:
       - master
   pull_request:
-
 jobs:
   test:
     runs-on: ubuntu-latest
     env:
       DFX_VERSION: 0.13.1
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Cache cargo build
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build
-      run: cargo build
-    - name: Run tests
-      run: cargo test
-    - name: fmt
-      run: cargo fmt -v -- --check
-    - name: lint
-      run: cargo clippy --tests -- -D clippy::all
-    - name: install dfx
-      run: |
-        echo y | DFX_VERSION=$DFX_VERSION bash -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-        echo '{}' > dfx.json
-        dfx start --background
-
-    - name: e2e tests
-      run: |
-        set -ex
-        target/debug/ic-repl examples/install.sh
-        target/debug/ic-repl examples/func.sh
+      - uses: actions/checkout@v2
+      - name: Install stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Cache cargo build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build
+        run: cargo build
+      - name: Run tests
+        run: cargo test
+      - name: fmt
+        run: cargo fmt -v -- --check
+      - name: lint
+        run: cargo clippy --tests -- -D clippy::all
+      - name: install dfx
+        run: |
+          echo y | DFX_VERSION=$DFX_VERSION bash -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+          echo '{}' > dfx.json
+          dfx start --background
+      - name: e2e tests
+        run: |
+          set -ex
+          target/debug/ic-repl examples/install.sh
+          target/debug/ic-repl examples/func.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ on:
   push:
     tags:
       - '*'
-
 jobs:
-  publish:
+  build:
     name: Release for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -24,38 +23,87 @@ jobs:
             name: arm
             artifact_name: target/arm-unknown-linux-gnueabihf/release/ic-repl
             asset_name: ic-repl-arm32
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Install stable toolchain
-      if: matrix.name != 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install stable ARM toolchain
-      if: matrix.name == 'arm'
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: arm-unknown-linux-gnueabihf
-    - name: Build
-      if: matrix.name != 'arm'
-      run: cargo build --release --locked
-    - name: Cross build
-      if: matrix.name == 'arm'
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --target arm-unknown-linux-gnueabihf --release --locked
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.asset_name }}
-        tag: ${{ github.ref }}
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        if: matrix.name != 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install stable ARM toolchain
+        if: matrix.name == 'arm'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: arm-unknown-linux-gnueabihf
+      - name: Build
+        if: matrix.name != 'arm'
+        run: cargo build --release --locked
+      - name: Cross build
+        if: matrix.name == 'arm'
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target arm-unknown-linux-gnueabihf --release --locked
+      - name: 'Upload assets'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.artifact_name }}
+          retention-days: 3
+  test:
+    needs: build
+    name: Test for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            asset_name: ic-repl-linux64
+          - os: ubuntu-20.04
+            asset_name: ic-repl-linux64
+          - os: macos-13
+            asset_name: ic-repl-macos
+          - os: macos-12
+            asset_name: ic-repl-macos
+          - os: macos-11
+            asset_name: ic-repl-macos
+    steps:
+      - name: Get executable
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Executable runs
+        run: |
+          chmod +x ic-repl
+          ./ic-repl --version
+  publish:
+    needs: test
+    name: Publish ${{ matrix.asset_name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset_name: ic-repl-linux64
+          - asset_name: ic-repl-arm32
+          - asset_name: ic-repl-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get executable
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.asset_name }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ic-repl
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             name: linux64
             artifact_name: target/release/ic-repl
             asset_name: ic-repl-linux64


### PR DESCRIPTION
# Motivation
The `ic-repl` releases do not currently work on Ubuntu 20.04, as described in #65 

# Changes
* Add smoke tests to verify that the executables run on various platforms before releasing.
* Build for Ubuntu on 20.04, as these builds are forwards compatible to 22.04 but builds on latest are not backwards compatible.

# Tests
* Build now work on 20.04:
![Screenshot from 2023-06-30 20-52-29](https://github.com/dfinity/ic-repl/assets/5982633/2940dd28-3bc4-4ff9-aaa0-5c94429969a4)

* However the release step requires permissions that I do not have as an external contributor.