### PR TITLE
Misc improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -68,33 +68,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -275,20 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
- "pairing",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,15 +294,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cached"
-version = "0.46.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c8c50262271cdf5abc979a5f76515c234e764fa025d1ba4862c0f0bcda0e95"
+checksum = "a8466736fe5dbcaf8b8ee24f9bbefe43c884dc3e9ff7178da70f55bffca1133c"
 dependencies = [
  "ahash",
  "hashbrown 0.14.5",
@@ -357,7 +343,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -391,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -409,9 +395,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -419,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -431,21 +417,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -474,9 +460,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "concurrent-queue"
@@ -616,11 +602,12 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -784,9 +771,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -903,16 +890,6 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
@@ -982,7 +959,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1055,22 +1032,11 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -1173,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -1259,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.36.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba85280257d8663adef20bf5c043b287b3a283d4f916073eb3ca9166a4a59d4b"
+checksum = "3fd3fdf5e5c4f4a9fe5ca612f0febd22dcb161d2f2b75b0142326732be5e4978"
 dependencies = [
  "async-lock",
  "backoff",
@@ -1278,13 +1244,13 @@ dependencies = [
  "k256",
  "leb128",
  "p256",
- "pem 2.0.1",
+ "pem",
  "pkcs8",
  "rand",
  "rangemap",
  "reqwest",
  "ring",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sec1",
  "serde",
  "serde_bytes",
@@ -1300,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20052ce9255fbe2de7041a4f6996fddd095ba1f31ae83b6c0ccdee5be6e7bbcf"
+checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
 dependencies = [
  "hex",
  "serde",
@@ -1312,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163ac173f5fc62a4c082ecaa1467efe83fe8534fca9edbeef3895f6a3df9b13b"
+checksum = "c6134e2869e833d741bf0a72d0dc750574f883e4ba8e012160a146c5a5344aec"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1326,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "ic-repl"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1347,7 +1313,7 @@ dependencies = [
  "lalrpop-util",
  "libflate",
  "logos",
- "pem 3.0.4",
+ "pem",
  "pretty",
  "pretty_assertions",
  "qrcode",
@@ -1366,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.36.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
@@ -1383,14 +1349,16 @@ dependencies = [
 
 [[package]]
 name = "ic-verify-bls-signature"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583b1c03380cf86059160cc6c91dcbf56c7b5f141bf3a4f06bc79762d775fac4"
+checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
 dependencies = [
- "bls12_381",
+ "hex",
+ "ic_bls12_381",
  "lazy_static",
  "pairing",
- "sha2 0.9.9",
+ "rand",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1404,6 +1372,20 @@ dependencies = [
  "rustc-demangle",
  "thiserror",
  "walrus",
+]
+
+[[package]]
+name = "ic_bls12_381"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
+dependencies = [
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1472,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.19"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
 dependencies = [
  "ahash",
  "crossbeam-channel",
@@ -1519,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1697,7 +1679,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1733,13 +1715,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1826,20 +1809,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -1876,11 +1849,11 @@ dependencies = [
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.12.1",
+ "group",
 ]
 
 [[package]]
@@ -1917,16 +1890,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
-dependencies = [
- "base64 0.21.7",
- "serde",
-]
 
 [[package]]
 name = "pem"
@@ -1984,7 +1947,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2040,7 +2003,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2208,14 +2171,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -2276,9 +2238,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2380,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.44"
+version = "0.8.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
+checksum = "ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523"
 dependencies = [
  "bytemuck",
 ]
@@ -2456,14 +2418,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.5",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2486,19 +2448,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2541,7 +2493,7 @@ checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2621,16 +2573,17 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2643,14 +2596,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -2859,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2908,22 +2861,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2983,32 +2936,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3037,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3049,18 +3001,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.15"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -3115,7 +3067,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3215,9 +3167,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3293,7 +3245,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -3327,7 +3279,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3565,9 +3517,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]
@@ -3605,7 +3557,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
- "gimli 0.28.1",
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arbitrary"
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -252,9 +252,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -296,9 +296,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5902d37352dffd8bd9177a2daa6444ce3cd0279c91763fb0171c053aa04335"
+checksum = "7df77a80c72fcd356cf37ff59c812f37ff06dc9a81232b3aff0a308cb5996904"
 dependencies = [
  "anyhow",
  "binread",
@@ -338,7 +338,7 @@ dependencies = [
  "hex",
  "ic_principal",
  "leb128",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "pretty",
@@ -357,14 +357,14 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "candid_parser"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d55a6757ccf6afca45b37eacd5ed554287e42842a724b5d86a96db1809d802"
+checksum = "6fa862dcc8beb3c250b335eaa388f169fa1575bb1476e09c9c78cbef88d510e4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -380,7 +380,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "pretty",
  "rand",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
 
 [[package]]
 name = "cfg-if"
@@ -409,9 +409,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -431,27 +431,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clipboard-win"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
 ]
@@ -535,27 +535,27 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -840,9 +840,9 @@ checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -982,7 +982,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "group"
@@ -1109,6 +1109,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -1182,12 +1183,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1195,15 +1196,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1220,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
@@ -1233,13 +1234,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1257,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f08d1b54f1834fb9637a57855f1d87bb9dbec7a9dec09499737580692829cb0"
+checksum = "ba85280257d8663adef20bf5c043b287b3a283d4f916073eb3ca9166a4a59d4b"
 dependencies = [
  "async-lock",
  "backoff",
@@ -1310,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65dca3c3ea390be68e88b5555cf460d5651c13cd7303e31bfe5832a4ddc2d6"
+checksum = "163ac173f5fc62a4c082ecaa1467efe83fe8534fca9edbeef3895f6a3df9b13b"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1364,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c68959f501cfcb79319b6720fd1903a661d77b503e6128bfce31f91ad87aca"
+checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
 dependencies = [
  "candid",
  "hex",
@@ -1393,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f3f1ec63f08807d176691225de0b993e832b1fff71c631ed897df5888c7be4"
+checksum = "9742ed6640abfc3bd1c8ca82de222e907275d1e851249b13fca7588f13759fc7"
 dependencies = [
  "candid",
  "libflate",
@@ -1465,6 +1467,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -1490,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1591,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -1603,9 +1606,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libflate"
@@ -1647,15 +1650,15 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1669,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
@@ -1694,7 +1697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1708,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1720,9 +1723,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -1760,7 +1763,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1779,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1834,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1888,9 +1891,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1906,7 +1909,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1952,9 +1955,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1963,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1973,22 +1976,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -2037,7 +2040,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2135,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2167,6 +2170,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2226,11 +2276,11 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2246,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2258,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2269,15 +2319,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2297,6 +2347,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2329,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.37"
+version = "0.8.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
 dependencies = [
  "bytemuck",
 ]
@@ -2385,12 +2436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2399,14 +2456,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.3",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
@@ -2439,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.3"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2460,7 +2517,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -2484,7 +2541,7 @@ checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2523,19 +2580,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.201"
+name = "semver"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -2552,20 +2615,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -2580,14 +2643,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -2674,7 +2737,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror",
  "time",
@@ -2773,9 +2836,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtle-ng"
@@ -2796,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2807,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"
@@ -2845,22 +2908,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2905,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2920,9 +2983,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2939,20 +3002,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -2974,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2986,18 +3049,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -3019,7 +3082,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3040,9 +3102,20 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -3107,9 +3180,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -3125,9 +3198,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3136,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -3158,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7"
+checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -3220,7 +3293,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
 
@@ -3254,7 +3327,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3267,9 +3340,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
 ]
@@ -3289,9 +3362,17 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.80.2"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "semver",
+ "serde",
+]
 
 [[package]]
 name = "web-sys"
@@ -3305,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3358,7 +3439,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3378,18 +3459,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3400,9 +3481,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3412,9 +3493,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3424,15 +3505,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3442,9 +3523,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3454,9 +3535,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3466,9 +3547,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3478,15 +3559,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -3509,26 +3590,26 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.63",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ codespan-reporting = "0.11"
 pretty = "0.12"
 pem = "3.0"
 shellexpand = "3.1"
-ic-agent = "0.35"
-ic-identity-hsm = "0.35"
-ic-transport-types = "0.35"
-ic-wasm = { version = "0.7", default-features = false }
+ic-agent = "0.36"
+ic-identity-hsm = "0.36"
+ic-transport-types = "0.36"
+ic-wasm = { version = "0.8", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["multithreaded", "nameattr"] }
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-repl"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["DFINITY Team"]
 edition = "2021"
 default-run = "ic-repl"
@@ -24,9 +24,9 @@ codespan-reporting = "0.11"
 pretty = "0.12"
 pem = "3.0"
 shellexpand = "3.1"
-ic-agent = "0.36"
-ic-identity-hsm = "0.36"
-ic-transport-types = "0.36"
+ic-agent = "0.37"
+ic-identity-hsm = "0.37"
+ic-transport-types = "0.37"
 ic-wasm = { version = "0.8", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["multithreaded", "nameattr"] }
 tokio = { version = "1.35", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ We also provide some built-in functions:
 * `and/or(e1, e2)/not(e)`: logical and/or/not.
 * `exist(e)`: check if `e` can be evaluated without errors. This is useful to check the existence of data, e.g., `exist(res[10])`.
 * `ite(cond, e1, e2)`: expression version of conditional branch. For example, `ite(exist(res.ok), "success", "error")`.
+* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns `null`. There are security risks in running arbitrary bash command. Be careful about what command you execute.
 
 The following functions are only available in non-offline mode:
 * `read_state([effective_id,] prefix, id, paths, ...)`: fetch the state tree path of `<prefix>/<id>/<paths>`. Some useful examples,
@@ -72,7 +73,7 @@ The following functions are only available in non-offline mode:
   + node public key: `read_state("subnet", principal "subnet_id", "node", principal "node_id", "public_key")`
 * `send(blob)`: send signed JSON messages generated from offline mode. The function can take a single message or an array of messages. Most likely use is `send(file("messages.json"))`. The return result is the return results of all calls. Alternatively, you can use `ic-repl -s messages.json -r ic`.
 
-There is a special `__main` function you can define in the script, which gets executed when loading from CLI. `__main` can take arguments provided from CLI. For example, the following code can be called with `ic-repl main.sh -- test 42` and outputs "test43".
+There is a special `__main` function you can define in the script, which gets executed when loading from CLI. `__main` can take arguments provided from CLI. The CLI arguments gets parsed by the Candid value parser first. If parsing fails, it is stored as a text value. For example, the following code can be called with `ic-repl main.sh -- test 42` and outputs "test43".
 
 ### main.sh
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ic-repl [--replica [local|ic|url] | --offline [--format [json|ascii|png]]] --con
 ```
 <command> := 
  | import <id> = <text> (as <text>)?                // bind canister URI to <id>, with optional did file
- | load <text>                                      // load and run a script file. Do not error out if <text> ends with '?'
+ | load <exp>                                       // load and run a script file. Do not error out if <exp> ends with '?'
  | config <text>                                    // set config in TOML format
  | let <id> = <exp>                                 // bind <exp> to a variable <id>
  | <exp>                                            // show the value of <exp>
@@ -71,6 +71,15 @@ The following functions are only available in non-offline mode:
   + list subnet nodes: `read_state("subnet", principal "subnet_id", "node")`
   + node public key: `read_state("subnet", principal "subnet_id", "node", principal "node_id", "public_key")`
 * `send(blob)`: send signed JSON messages generated from offline mode. The function can take a single message or an array of messages. Most likely use is `send(file("messages.json"))`. The return result is the return results of all calls. Alternatively, you can use `ic-repl -s messages.json -r ic`.
+
+There is a special `__main` function you can define in the script, which gets executed when loading from CLI. `__main` can take arguments provided from CLI. For example, the following code can be called with `ic-repl main.sh -- test 42` and outputs "test43".
+
+### main.sh
+```
+function __main(name, n) {
+  stringify(name, add(n, 1))
+}
+```
 
 ## Object methods
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We also provide some built-in functions:
 * `and/or(e1, e2)/not(e)`: logical and/or/not.
 * `exist(e)`: check if `e` can be evaluated without errors. This is useful to check the existence of data, e.g., `exist(res[10])`.
 * `ite(cond, e1, e2)`: expression version of conditional branch. For example, `ite(exist(res.ok), "success", "error")`.
-* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns `null`. There are security risks in running arbitrary bash command. Be careful about what command you execute.
+* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns that line as a text value. There are security risks in running arbitrary bash command. Be careful about what command you execute.
 
 The following functions are only available in non-offline mode:
 * `read_state([effective_id,] prefix, id, paths, ...)`: fetch the state tree path of `<prefix>/<id>/<paths>`. Some useful examples,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Canister REPL
 
 ```
-ic-repl [--replica [local|ic|url] | --offline [--format [json|ascii|png]]] --config <toml config> [script file]
+ic-repl [--replica [local|ic|url] | --offline [--format [json|ascii|png]]] --config <toml config> [script file] --verbose
 ```
 
 ## Commands
@@ -61,7 +61,7 @@ We also provide some built-in functions:
 * `and/or(e1, e2)/not(e)`: logical and/or/not.
 * `exist(e)`: check if `e` can be evaluated without errors. This is useful to check the existence of data, e.g., `exist(res[10])`.
 * `ite(cond, e1, e2)`: expression version of conditional branch. For example, `ite(exist(res.ok), "success", "error")`.
-* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns that line as a text value. There are security risks in running arbitrary bash command. Be careful about what command you execute.
+* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns that line as a text value. If you want to hide the stdout and stderr, use `exec_silence` function with the same arguments. There are security risks in running arbitrary bash command. Be careful about what command you execute.
 
 The following functions are only available in non-offline mode:
 * `read_state([effective_id,] prefix, id, paths, ...)`: fetch the state tree path of `<prefix>/<id>/<paths>`. Some useful examples,

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We also provide some built-in functions:
 * `and/or(e1, e2)/not(e)`: logical and/or/not.
 * `exist(e)`: check if `e` can be evaluated without errors. This is useful to check the existence of data, e.g., `exist(res[10])`.
 * `ite(cond, e1, e2)`: expression version of conditional branch. For example, `ite(exist(res.ok), "success", "error")`.
-* `exec(cmd, arg1, arg2, ...)`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns that line as a text value. If you want to hide the stdout and stderr, use `exec_silence` function with the same arguments. There are security risks in running arbitrary bash command. Be careful about what command you execute.
+* `exec(cmd, arg1, arg2, ...)/exec(cmd, arg1, arg2, ..., record { silence = <bool>; cwd = <text> })`: execute a bash command. The arguments are all text types. The last line from stdout is parsed by the Candid value parser as the result of the `exec` function. If parsing fails, returns that line as a text value. You can specify an optional record argument at the end. All fields in the record are optional. If provided, `silence = true` hides the stdout and stderr output; `cwd` specifies the current working directory of the command. There are security risks in running arbitrary bash command. Be careful about what command you execute.
 
 The following functions are only available in non-offline mode:
 * `read_state([effective_id,] prefix, id, paths, ...)`: fetch the state tree path of `<prefix>/<id>/<paths>`. Some useful examples,

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ ic-repl [--replica [local|ic|url] | --offline [--format [json|ascii|png]]] --con
 ```
 <command> := 
  | import <id> = <text> (as <text>)?                // bind canister URI to <id>, with optional did file
- | export <text>                                    // export current environment variables
- | load <text>                                      // load and run a script file
+ | load <text>                                      // load and run a script file. Do not error out if <text> ends with '?'
  | config <text>                                    // set config in TOML format
  | let <id> = <exp>                                 // bind <exp> to a variable <id>
  | <exp>                                            // show the value of <exp>
@@ -52,6 +51,7 @@ We also provide some built-in functions:
 * `gzip(blob)`: gzip a blob value.
 * `stringify(exp1, exp2, exp3, ...)`: convert all expressions to string and concat. Only supports primitive types.
 * `output(path, content)`: append text content to file path.
+* `export(path, var1, var2, ...)`: overwrite variable bindings to file path. The file can be used by the `load` command.
 * `wasm_profiling(path)/wasm_profiling(path, record { trace_only_funcs = <vec text>; start_page = <nat>; page_limit = <nat> })`: load Wasm module, instrument the code and store as a blob value. Calling profiled canister binds the cost to variable `__cost_{id}` or `__cost__`. The second argument is optional, and all fields in the record are also optional. If provided, `trace_only_funcs` will only count and trace the provided set of functions; `start_page` writes the logs to a preallocated pages in stable memory; `page_limit` specifies the number of the preallocated pages, default to 4096 if omitted. See [ic-wasm's doc](https://github.com/dfinity/ic-wasm#working-with-upgrades-and-stable-memory) for more details.
 * `flamegraph(canister_id, title, filename)`: generate flamegraph for the last update call to canister_id, with title and write to `{filename}.svg`. The cost of the update call is returned.
 * `concat(e1, e2)`: concatenate two vec/record/text together.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We also provide some built-in functions:
 * `neuron_account(principal, nonce)`: convert (principal, nonce) to account in the governance canister.
 * `file(path)`: load external file as a blob value.
 * `gzip(blob)`: gzip a blob value.
+* `replica_url()`: returns the replica URL ic-repl connects to.
 * `stringify(exp1, exp2, exp3, ...)`: convert all expressions to string and concat. Only supports primitive types.
 * `output(path, content)`: append text content to file path.
 * `export(path, var1, var2, ...)`: overwrite variable bindings to file path. The file can be used by the `load` command.

--- a/examples/func.sh
+++ b/examples/func.sh
@@ -89,9 +89,11 @@ function fib3(n) {
       let _ = add(fib3(sub(n, 1)), fib3(sub(n, 2)));
   }
 };
+function __main() {
 assert fac(5) == 120;
 assert fac2(5) == 120;
 assert fac3(5) == 120;
 assert fib(10) == 89;
 assert fib2(10) == 89;
 assert fib3(10) == 89;
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,7 +20,7 @@ pub enum Command {
     Let(String, Exp),
     Assert(BinOp, Exp, Exp),
     Import(String, Principal, Option<String>),
-    Load(String),
+    Load(Exp),
     Identity(String, IdentityConfig),
     Func {
         name: String,
@@ -163,8 +163,11 @@ impl Command {
                 helper.current_identity = id.to_string();
                 helper.env.0.insert(id, IDLValue::Principal(sender));
             }
-            Command::Load(file) => {
+            Command::Load(e) => {
                 // TODO check for infinite loop
+                let IDLValue::Text(file) = e.eval(helper)? else {
+                    return Err(anyhow!("load needs to be a file path"));
+                };
                 let (file, fail_safe) = if file.ends_with('?') {
                     (file.trim_end_matches('?'), true)
                 } else {

--- a/src/command.rs
+++ b/src/command.rs
@@ -165,6 +165,7 @@ impl Command {
             }
             Command::Load(e) => {
                 // TODO check for infinite loop
+                // Note that it's a bit tricky to make load as a built-in function, as it requires mutable access to helper.
                 let IDLValue::Text(file) = e.eval(helper)? else {
                     return Err(anyhow!("load needs to be a file path"));
                 };

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -123,7 +123,7 @@ impl Exp {
                     "export" => {
                         use std::io::{BufWriter, Write};
                         if exps.len() <= 1 {
-                            return Err(anyhow!("export expects at least two argument"));
+                            return Err(anyhow!("export expects at least two arguments"));
                         }
                         let path = exps[0].clone().eval(helper)?;
                         let IDLValue::Text(path) = path else {
@@ -176,7 +176,7 @@ impl Exp {
                     },
                     "replica_url" => match args.as_slice() {
                         [] => IDLValue::Text(helper.agent_url.clone()),
-                        _ => return Err(anyhow!("replica_url expects no argument")),
+                        _ => return Err(anyhow!("replica_url expects no arguments")),
                     },
                     "read_state" if helper.offline.is_none() => {
                         use crate::utils::{fetch_state_path, parse_state_path};

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -174,6 +174,10 @@ impl Exp {
                         }
                         _ => return Err(anyhow!("neuron_account expects (principal, nonce)")),
                     },
+                    "replica_url" => match args.as_slice() {
+                        [] => IDLValue::Text(helper.agent_url.clone()),
+                        _ => return Err(anyhow!("replica_url expects no argument")),
+                    },
                     "read_state" if helper.offline.is_none() => {
                         use crate::utils::{fetch_state_path, parse_state_path};
                         match args.as_slice() {

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -261,7 +261,8 @@ impl Exp {
                                 ));
                             }
                             let stdout = final_stdout.lock().unwrap();
-                            candid_parser::parse_idl_value(&stdout).unwrap_or(IDLValue::Null)
+                            candid_parser::parse_idl_value(&stdout)
+                                .unwrap_or(IDLValue::Text(stdout.clone()))
                         }
                         _ => return Err(anyhow!("exec expects (text command, ...text args)")),
                     },

--- a/src/governance.did
+++ b/src/governance.did
@@ -1,4 +1,5 @@
-type AccountIdentifier = record { hash : vec nat8 };
+
+type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
@@ -33,13 +34,17 @@ type CanisterStatusResultV2 = record {
   memory_size : opt nat64;
   cycles : opt nat64;
   idle_cycles_burned_per_day : opt nat64;
-  module_hash : vec nat8;
+  module_hash : blob;
 };
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
-type CfNeuron = record { nns_neuron_id : nat64; amount_icp_e8s : nat64 };
+type CfNeuron = record {
+  has_created_neuron_recipes : opt bool;
+  nns_neuron_id : nat64;
+  amount_icp_e8s : nat64;
+};
 type CfParticipant = record {
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
@@ -100,6 +105,11 @@ type Committed = record {
   total_neurons_fund_contribution_icp_e8s : opt nat64;
   sns_governance_canister_id : opt principal;
 };
+type Committed_1 = record {
+  total_direct_participation_icp_e8s : opt nat64;
+  total_neurons_fund_participation_icp_e8s : opt nat64;
+  sns_governance_canister_id : opt principal;
+};
 type Configure = record { operation : opt Operation };
 type Countries = record { iso_codes : vec text };
 type CreateServiceNervousSystem = record {
@@ -114,6 +124,7 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+type Decimal = record { human_readable : opt text };
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
 };
@@ -137,14 +148,18 @@ type DissolveState = variant {
   WhenDissolvedTimestampSeconds : nat64;
 };
 type Duration = record { seconds : opt nat64 };
-type ExecuteNnsFunction = record { nns_function : int32; payload : vec nat8 };
+type ExecuteNnsFunction = record { nns_function : int32; payload : blob };
 type Follow = record { topic : int32; followees : vec NeuronId };
 type Followees = record { followees : vec NeuronId };
+type Followers = record { followers : vec NeuronId };
+type FollowersMap = record { followers_map : vec record { nat64; Followers } };
+type GetNeuronsFundAuditInfoRequest = record { nns_proposal_id : opt NeuronId };
+type GetNeuronsFundAuditInfoResponse = record { result : opt Result_6 };
 type GlobalTimeOfDay = record { seconds_after_utc_midnight : opt nat64 };
 type Governance = record {
   default_followees : vec record { int32; Followees };
   making_sns_proposal : opt MakingSnsProposal;
-  most_recent_monthly_node_provider_rewards : opt MostRecentMonthlyNodeProviderRewards;
+  most_recent_monthly_node_provider_rewards : opt MonthlyNodeProviderRewards;
   maturity_modulation_last_updated_at_timestamp_seconds : opt nat64;
   wait_for_quiet_threshold_seconds : nat64;
   metrics : opt GovernanceCachedMetrics;
@@ -152,12 +167,15 @@ type Governance = record {
   node_providers : vec NodeProvider;
   cached_daily_maturity_modulation_basis_points : opt int32;
   economics : opt NetworkEconomics;
+  restore_aging_summary : opt RestoreAgingSummary;
   spawning_neurons : opt bool;
   latest_reward_event : opt RewardEvent;
   to_claim_transfers : vec NeuronStakeTransfer;
   short_voting_period_seconds : nat64;
+  topic_followee_index : vec record { int32; FollowersMap };
   migrations : opt Migrations;
   proposals : vec record { nat64; ProposalData };
+  xdr_conversion_rate : opt XdrConversionRate;
   in_flight_commands : vec record { nat64; NeuronInFlightCommand };
   neurons : vec record { nat64; Neuron };
   genesis_timestamp_seconds : nat64;
@@ -173,27 +191,40 @@ type GovernanceCachedMetrics = record {
   };
   neurons_with_invalid_stake_count : nat64;
   not_dissolving_neurons_count_buckets : vec record { nat64; nat64 };
+  ect_neuron_count : nat64;
   total_supply_icp : nat64;
   neurons_with_less_than_6_months_dissolve_delay_count : nat64;
   dissolved_neurons_count : nat64;
   community_fund_total_maturity_e8s_equivalent : nat64;
+  total_staked_e8s_seed : nat64;
+  total_staked_maturity_e8s_equivalent_ect : nat64;
   total_staked_e8s : nat64;
   not_dissolving_neurons_count : nat64;
   total_locked_e8s : nat64;
   neurons_fund_total_active_neurons : nat64;
+  total_voting_power_non_self_authenticating_controller : opt nat64;
   total_staked_maturity_e8s_equivalent : nat64;
+  not_dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
+  total_staked_e8s_ect : nat64;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum : nat64;
   dissolved_neurons_e8s : nat64;
+  total_staked_e8s_non_self_authenticating_controller : opt nat64;
+  dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   neurons_with_less_than_6_months_dissolve_delay_e8s : nat64;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_buckets : vec record {
     nat64;
     float64;
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
+  dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
+  total_staked_maturity_e8s_equivalent_seed : nat64;
   community_fund_total_staked_e8s : nat64;
+  not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
+  seed_neuron_count : nat64;
 };
 type GovernanceError = record { error_message : text; error_type : int32 };
 type GovernanceParameters = record {
@@ -207,6 +238,9 @@ type GovernanceParameters = record {
   proposal_initial_voting_period : opt Duration;
   proposal_rejection_fee : opt Tokens;
   voting_reward_parameters : opt VotingRewardParameters;
+};
+type IdealMatchedParticipationFunction = record {
+  serialized_representation : opt text;
 };
 type Image = record { base64_encoding : opt text };
 type IncreaseDissolveDelay = record {
@@ -231,6 +265,7 @@ type LedgerParameters = record {
 type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
 type ListNeurons = record {
   neuron_ids : vec nat64;
+  include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
 };
 type ListNeuronsResponse = record {
@@ -248,7 +283,10 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
-type MakeProposalResponse = record { proposal_id : opt NeuronId };
+type MakeProposalResponse = record {
+  message : opt text;
+  proposal_id : opt NeuronId;
+};
 type MakingSnsProposal = record {
   proposal : opt Proposal;
   caller : opt principal;
@@ -281,9 +319,14 @@ type Migrations = record {
   neuron_indexes_migration : opt Migration;
   copy_inactive_neurons_to_stable_memory_migration : opt Migration;
 };
-type MostRecentMonthlyNodeProviderRewards = record {
+type MonthlyNodeProviderRewards = record {
+  minimum_xdr_permyriad_per_icp : opt nat64;
+  registry_version : opt nat64;
+  node_providers : vec NodeProvider;
   timestamp : nat64;
   rewards : vec RewardNodeProvider;
+  xdr_conversion_rate : opt XdrConversionRate;
+  maximum_node_provider_rewards_e8s : opt nat64;
 };
 type Motion = record { motion_text : text };
 type NetworkEconomics = record {
@@ -295,6 +338,7 @@ type NetworkEconomics = record {
   neuron_spawn_dissolve_delay_seconds : nat64;
   minimum_icp_xdr_rate : nat64;
   maximum_node_provider_rewards_e8s : nat64;
+  neurons_fund_economics : opt NeuronsFundEconomics;
 };
 type Neuron = record {
   id : opt NeuronId;
@@ -302,6 +346,7 @@ type Neuron = record {
   controller : opt principal;
   recent_ballots : vec BallotInfo;
   kyc_verified : bool;
+  neuron_type : opt int32;
   not_for_profit : bool;
   maturity_e8s_equivalent : nat64;
   cached_neuron_stake_e8s : nat64;
@@ -309,7 +354,7 @@ type Neuron = record {
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
   hot_keys : vec principal;
-  account : vec nat8;
+  account : blob;
   joined_community_fund_timestamp_seconds : opt nat64;
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
@@ -334,10 +379,7 @@ type NeuronDistribution = record {
   stake : opt Tokens;
 };
 type NeuronId = record { id : nat64 };
-type NeuronIdOrSubaccount = variant {
-  Subaccount : vec nat8;
-  NeuronId : NeuronId;
-};
+type NeuronIdOrSubaccount = variant { Subaccount : blob; NeuronId : NeuronId };
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
@@ -345,6 +387,7 @@ type NeuronInFlightCommand = record {
 type NeuronInfo = record {
   dissolve_delay_seconds : nat64;
   recent_ballots : vec BallotInfo;
+  neuron_type : opt int32;
   created_timestamp_seconds : nat64;
   state : int32;
   stake_e8s : nat64;
@@ -355,18 +398,81 @@ type NeuronInfo = record {
   age_seconds : nat64;
 };
 type NeuronStakeTransfer = record {
-  to_subaccount : vec nat8;
+  to_subaccount : blob;
   neuron_stake_e8s : nat64;
   from : opt principal;
   memo : nat64;
-  from_subaccount : vec nat8;
+  from_subaccount : blob;
   transfer_timestamp : nat64;
   block_height : nat64;
+};
+type NeuronSubsetMetrics = record {
+  total_maturity_e8s_equivalent : opt nat64;
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  voting_power_buckets : vec record { nat64; nat64 };
+  total_staked_e8s : opt nat64;
+  count : opt nat64;
+  total_staked_maturity_e8s_equivalent : opt nat64;
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  total_voting_power : opt nat64;
+  count_buckets : vec record { nat64; nat64 };
+};
+type NeuronsFundAuditInfo = record {
+  final_neurons_fund_participation : opt NeuronsFundParticipation;
+  initial_neurons_fund_participation : opt NeuronsFundParticipation;
+  neurons_fund_refunds : opt NeuronsFundSnapshot;
+};
+type NeuronsFundData = record {
+  final_neurons_fund_participation : opt NeuronsFundParticipation;
+  initial_neurons_fund_participation : opt NeuronsFundParticipation;
+  neurons_fund_refunds : opt NeuronsFundSnapshot;
+};
+type NeuronsFundEconomics = record {
+  maximum_icp_xdr_rate : opt Percentage;
+  neurons_fund_matched_funding_curve_coefficients : opt NeuronsFundMatchedFundingCurveCoefficients;
+  max_theoretical_neurons_fund_participation_amount_xdr : opt Decimal;
+  minimum_icp_xdr_rate : opt Percentage;
+};
+type NeuronsFundMatchedFundingCurveCoefficients = record {
+  contribution_threshold_xdr : opt Decimal;
+  one_third_participation_milestone_xdr : opt Decimal;
+  full_participation_milestone_xdr : opt Decimal;
+};
+type NeuronsFundNeuron = record {
+  hotkey_principal : opt text;
+  is_capped : opt bool;
+  nns_neuron_id : opt nat64;
+  amount_icp_e8s : opt nat64;
+};
+type NeuronsFundNeuronPortion = record {
+  controller : opt principal;
+  hotkey_principal : opt principal;
+  hotkeys : vec principal;
+  is_capped : opt bool;
+  maturity_equivalent_icp_e8s : opt nat64;
+  nns_neuron_id : opt NeuronId;
+  amount_icp_e8s : opt nat64;
+};
+type NeuronsFundParticipation = record {
+  total_maturity_equivalent_icp_e8s : opt nat64;
+  intended_neurons_fund_participation_icp_e8s : opt nat64;
+  direct_participation_icp_e8s : opt nat64;
+  swap_participation_limits : opt SwapParticipationLimits;
+  max_neurons_fund_swap_participation_icp_e8s : opt nat64;
+  neurons_fund_reserves : opt NeuronsFundSnapshot;
+  ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
+  allocated_neurons_fund_participation_icp_e8s : opt nat64;
+};
+type NeuronsFundSnapshot = record {
+  neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
 };
+type Ok = record { neurons_fund_audit_info : opt NeuronsFundAuditInfo };
+type Ok_1 = record { neurons_fund_neuron_portions : vec NeuronsFundNeuron };
 type OpenSnsTokenSwap = record {
   community_fund_investment_e8s : opt nat64;
   target_swap_canister_id : opt principal;
@@ -392,7 +498,9 @@ type Params = record {
   sns_token_e8s : nat64;
   sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
+  min_direct_participation_icp_e8s : opt nat64;
   min_icp_e8s : nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Percentage = record { basis_points : opt nat64 };
 type Progress = variant { LastNeuronId : NeuronId };
@@ -410,6 +518,7 @@ type ProposalData = record {
   proposal_timestamp_seconds : nat64;
   reward_event_round : nat64;
   failed_timestamp_seconds : nat64;
+  neurons_fund_data : opt NeuronsFundData;
   reject_cost_e8s : nat64;
   derived_proposal_information : opt DerivedProposalInformation;
   latest_tally : opt Tally;
@@ -442,14 +551,27 @@ type ProposalInfo = record {
 };
 type RegisterVote = record { vote : int32; proposal : opt NeuronId };
 type RemoveHotKey = record { hot_key_to_remove : opt principal };
+type RestoreAgingNeuronGroup = record {
+  count : opt nat64;
+  previous_total_stake_e8s : opt nat64;
+  current_total_stake_e8s : opt nat64;
+  group_type : int32;
+};
+type RestoreAgingSummary = record {
+  groups : vec RestoreAgingNeuronGroup;
+  timestamp_seconds : opt nat64;
+};
 type Result = variant { Ok; Err : GovernanceError };
 type Result_1 = variant { Error : GovernanceError; NeuronId : NeuronId };
+type Result_10 = variant { Ok : Ok_1; Err : GovernanceError };
 type Result_2 = variant { Ok : Neuron; Err : GovernanceError };
 type Result_3 = variant { Ok : GovernanceCachedMetrics; Err : GovernanceError };
 type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
 type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
-type Result_6 = variant { Ok : NodeProvider; Err : GovernanceError };
-type Result_7 = variant { Committed : Committed; Aborted : record {} };
+type Result_6 = variant { Ok : Ok; Err : GovernanceError };
+type Result_7 = variant { Ok : NodeProvider; Err : GovernanceError };
+type Result_8 = variant { Committed : Committed; Aborted : record {} };
+type Result_9 = variant { Committed : Committed_1; Aborted : record {} };
 type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   day_after_genesis : nat64;
@@ -484,9 +606,14 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   swap_canister_id : opt principal;
 };
 type SettleCommunityFundParticipation = record {
-  result : opt Result_7;
+  result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;
 };
+type SettleNeuronsFundParticipationRequest = record {
+  result : opt Result_9;
+  nns_proposal_id : opt nat64;
+};
+type SettleNeuronsFundParticipationResponse = record { result : opt Result_10 };
 type Spawn = record {
   percentage_to_spawn : opt nat32;
   new_controller : opt principal;
@@ -512,16 +639,25 @@ type SwapBackgroundInformation = record {
 type SwapDistribution = record { total : opt Tokens };
 type SwapParameters = record {
   minimum_participants : opt nat64;
+  neurons_fund_participation : opt bool;
   duration : opt Duration;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
   confirmation_text : opt text;
   maximum_participant_icp : opt Tokens;
   minimum_icp : opt Tokens;
+  minimum_direct_participation_icp : opt Tokens;
   minimum_participant_icp : opt Tokens;
   start_time : opt GlobalTimeOfDay;
+  maximum_direct_participation_icp : opt Tokens;
   maximum_icp : opt Tokens;
   neurons_fund_investment_icp : opt Tokens;
   restricted_countries : opt Countries;
+};
+type SwapParticipationLimits = record {
+  min_participant_icp_e8s : opt nat64;
+  max_participant_icp_e8s : opt nat64;
+  min_direct_participation_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Tally = record {
   no : nat64;
@@ -541,6 +677,10 @@ type VotingRewardParameters = record {
   final_reward_rate : opt Percentage;
 };
 type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
+type XdrConversionRate = record {
+  xdr_permyriad_per_icp : opt nat64;
+  timestamp_seconds : opt nat64;
+};
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (
@@ -555,7 +695,7 @@ service : (Governance) -> {
   get_metrics : () -> (Result_3) query;
   get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (
-      opt MostRecentMonthlyNodeProviderRewards,
+      opt MonthlyNodeProviderRewards,
     ) query;
   get_network_economics_parameters : () -> (NetworkEconomics) query;
   get_neuron_ids : () -> (vec nat64) query;
@@ -563,9 +703,13 @@ service : (Governance) -> {
   get_neuron_info_by_id_or_subaccount : (NeuronIdOrSubaccount) -> (
       Result_5,
     ) query;
-  get_node_provider_by_caller : (null) -> (Result_6) query;
+  get_neurons_fund_audit_info : (GetNeuronsFundAuditInfoRequest) -> (
+      GetNeuronsFundAuditInfoResponse,
+    ) query;
+  get_node_provider_by_caller : (null) -> (Result_7) query;
   get_pending_proposals : () -> (vec ProposalInfo) query;
   get_proposal_info : (nat64) -> (opt ProposalInfo) query;
+  get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
@@ -574,6 +718,9 @@ service : (Governance) -> {
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
+  settle_neurons_fund_participation : (
+      SettleNeuronsFundParticipationRequest,
+    ) -> (SettleNeuronsFundParticipationResponse);
   simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -74,7 +74,7 @@ pub Command: Command = {
     Exp => Command::Show(<>),
     "assert" <left:Exp> <op:BinOp> <right:Exp> => Command::Assert(op, left, right),
     "let" <id:"id"> "=" <val:Exp> => Command::Let(id, val),
-    "load" <Text> => Command::Load(<>),
+    "load" <Exp> => Command::Load(<>),
     "import" <id:"id"> "=" <uri:Sp<Text>> <did:("as" <Text>)?> =>? {
          let principal = Principal::from_text(&uri.0).map_err(|e| error2(e, uri.1))?;
          Ok(Command::Import(id, principal, did))

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -31,7 +31,6 @@ extern {
         "blob" => Token::Blob,
         "type" => Token::Type,
         "import" => Token::Import,
-        "export" => Token::Export,
         "load" => Token::Load,
         "principal" => Token::Principal,
         "call" => Token::Call,
@@ -75,7 +74,6 @@ pub Command: Command = {
     Exp => Command::Show(<>),
     "assert" <left:Exp> <op:BinOp> <right:Exp> => Command::Assert(op, left, right),
     "let" <id:"id"> "=" <val:Exp> => Command::Let(id, val),
-    "export" <Text> => Command::Export(<>),
     "load" <Text> => Command::Load(<>),
     "import" <id:"id"> "=" <uri:Sp<Text>> <did:("as" <Text>)?> =>? {
          let principal = Principal::from_text(&uri.0).map_err(|e| error2(e, uri.1))?;

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -171,6 +171,11 @@ impl MyHelper {
                 Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai")?,
                 self.offline.as_ref().map(|_| include_str!("ledger.did")),
             )?;
+            self.preload_canister(
+                "cycles".to_string(),
+                Principal::from_text("um5iw-rqaaa-aaaaq-qaaba-cai")?,
+                None,
+            )?;
         }
         Ok(())
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -172,7 +172,12 @@ impl MyHelper {
                 self.offline.as_ref().map(|_| include_str!("ledger.did")),
             )?;
             self.preload_canister(
-                "cycles".to_string(),
+                "registry".to_string(),
+                Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai")?,
+                None,
+            )?;
+            self.preload_canister(
+                "cycles_ledger".to_string(),
                 Principal::from_text("um5iw-rqaaa-aaaaq-qaaba-cai")?,
                 None,
             )?;

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -90,6 +90,7 @@ pub struct MyHelper {
     pub func_env: FuncEnv,
     pub base_path: std::path::PathBuf,
     pub messages: RefCell<Vec<crate::offline::IngressWithStatus>>,
+    pub verbose: bool,
 }
 
 impl MyHelper {
@@ -111,9 +112,15 @@ impl MyHelper {
             agent_url: self.agent_url.clone(),
             offline: self.offline.clone(),
             messages: self.messages.clone(),
+            verbose: self.verbose,
         }
     }
-    pub fn new(agent: Agent, agent_url: String, offline: Option<OfflineOutput>) -> Self {
+    pub fn new(
+        agent: Agent,
+        agent_url: String,
+        offline: Option<OfflineOutput>,
+        verbose: bool,
+    ) -> Self {
         let mut res = MyHelper {
             completer: FilenameCompleter::new(),
             highlighter: MatchingBracketHighlighter::new(),
@@ -131,6 +138,7 @@ impl MyHelper {
             agent,
             agent_url,
             offline,
+            verbose,
         };
         res.fetch_root_key_if_needed().unwrap();
         res.load_prelude().unwrap();
@@ -578,8 +586,8 @@ impl Env {
 fn test_partial_parse() -> anyhow::Result<()> {
     use candid_parser::parse_idl_value;
     let url = "https://icp0.io".to_string();
-    let agent = Agent::builder().with_url(url).build()?;
-    let mut helper = MyHelper::new(agent, url, None);
+    let agent = Agent::builder().with_url(url.clone()).build()?;
+    let mut helper = MyHelper::new(agent, url, None, false);
     helper.env.0.insert(
         "a".to_string(),
         parse_idl_value("opt record { variant {b=vec{1;2;3}}; 42; f1=42;42=35;a1=30}")?,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -578,11 +578,7 @@ impl Env {
 fn test_partial_parse() -> anyhow::Result<()> {
     use candid_parser::parse_idl_value;
     let url = "https://icp0.io".to_string();
-    let agent = Agent::builder()
-        .with_transport(ic_agent::agent::http_transport::ReqwestTransport::create(
-            url.clone(),
-        )?)
-        .build()?;
+    let agent = Agent::builder().with_url(url).build()?;
     let mut helper = MyHelper::new(agent, url, None);
     helper.env.0.insert(
         "a".to_string(),

--- a/src/ic.did
+++ b/src/ic.did
@@ -1,66 +1,86 @@
 type canister_id = principal;
 type wasm_module = blob;
 
+type log_visibility = variant {
+    controllers;
+    public;
+};
+
 type canister_settings = record {
-  controllers : opt vec principal;
-  compute_allocation : opt nat;
-  memory_allocation : opt nat;
-  freezing_threshold : opt nat;
+    controllers : opt vec principal;
+    compute_allocation : opt nat;
+    memory_allocation : opt nat;
+    freezing_threshold : opt nat;
+    reserved_cycles_limit : opt nat;
+    log_visibility : opt log_visibility;
+    wasm_memory_limit : opt nat;
 };
 
 type definite_canister_settings = record {
-  controllers : vec principal;
-  compute_allocation : nat;
-  memory_allocation : nat;
-  freezing_threshold : nat;
+    controllers : vec principal;
+    compute_allocation : nat;
+    memory_allocation : nat;
+    freezing_threshold : nat;
+    reserved_cycles_limit : nat;
+    log_visibility : log_visibility;
+    wasm_memory_limit : nat;
 };
 
 type change_origin = variant {
-  from_user : record {
-    user_id : principal;
-  };
-  from_canister : record {
-    canister_id : principal;
-    canister_version : opt nat64;
-  };
+    from_user : record {
+        user_id : principal;
+    };
+    from_canister : record {
+        canister_id : principal;
+        canister_version : opt nat64;
+    };
 };
 
 type change_details = variant {
-  creation : record {
-    controllers : vec principal;
-  };
-  code_uninstall;
-  code_deployment : record {
-    mode : variant {install; reinstall; upgrade};
-    module_hash : blob;
-  };
-  controllers_change : record {
-    controllers : vec principal;
-  };
+    creation : record {
+        controllers : vec principal;
+    };
+    code_uninstall;
+    code_deployment : record {
+        mode : variant { install; reinstall; upgrade };
+        module_hash : blob;
+    };
+    controllers_change : record {
+        controllers : vec principal;
+    };
 };
 
 type change = record {
-  timestamp_nanos : nat64;
-  canister_version : nat64;
-  origin : change_origin;
-  details : change_details;
+    timestamp_nanos : nat64;
+    canister_version : nat64;
+    origin : change_origin;
+    details : change_details;
 };
 
-type http_header = record { name: text; value: text };
-
-type http_response = record {
-  status: nat;
-  headers: vec http_header;
-  body: blob;
+type chunk_hash = record {
+  hash : blob;
 };
 
-type ecdsa_curve = variant { secp256k1; };
+type http_header = record {
+    name : text;
+    value : text;
+};
+
+type http_request_result = record {
+    status : nat;
+    headers : vec http_header;
+    body : blob;
+};
+
+type ecdsa_curve = variant {
+    secp256k1;
+};
 
 type satoshi = nat64;
 
 type bitcoin_network = variant {
-  mainnet;
-  testnet;
+    mainnet;
+    testnet;
 };
 
 type bitcoin_address = text;
@@ -68,128 +88,310 @@ type bitcoin_address = text;
 type block_hash = blob;
 
 type outpoint = record {
-  txid : blob;
-  vout : nat32
+    txid : blob;
+    vout : nat32;
 };
 
 type utxo = record {
-  outpoint: outpoint;
-  value: satoshi;
-  height: nat32;
+    outpoint : outpoint;
+    value : satoshi;
+    height : nat32;
 };
 
-type get_utxos_request = record {
-  address : bitcoin_address;
-  network: bitcoin_network;
-  filter: opt variant {
-    min_confirmations: nat32;
-    page: blob;
-  };
+type bitcoin_get_utxos_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    filter : opt variant {
+        min_confirmations : nat32;
+        page : blob;
+    };
 };
 
-type get_current_fee_percentiles_request = record {
-  network: bitcoin_network;
+type bitcoin_get_utxos_query_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    filter : opt variant {
+        min_confirmations : nat32;
+        page : blob;
+    };
 };
 
-type get_utxos_response = record {
-  utxos: vec utxo;
-  tip_block_hash: block_hash;
-  tip_height: nat32;
-  next_page: opt blob;
+type bitcoin_get_current_fee_percentiles_args = record {
+    network : bitcoin_network;
 };
 
-type get_balance_request = record {
-  address : bitcoin_address;
-  network: bitcoin_network;
-  min_confirmations: opt nat32;
+type bitcoin_get_utxos_result = record {
+    utxos : vec utxo;
+    tip_block_hash : block_hash;
+    tip_height : nat32;
+    next_page : opt blob;
 };
 
-type send_transaction_request = record {
-  transaction: blob;
-  network: bitcoin_network;
+type bitcoin_get_utxos_query_result = record {
+    utxos : vec utxo;
+    tip_block_hash : block_hash;
+    tip_height : nat32;
+    next_page : opt blob;
+};
+
+type bitcoin_get_balance_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    min_confirmations : opt nat32;
+};
+
+type bitcoin_get_balance_query_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    min_confirmations : opt nat32;
+};
+
+type bitcoin_send_transaction_args = record {
+    transaction : blob;
+    network : bitcoin_network;
 };
 
 type millisatoshi_per_byte = nat64;
 
-service ic : {
-  create_canister : (record {
+type node_metrics = record {
+    node_id : principal;
+    num_blocks_proposed_total : nat64;
+    num_block_failures_total : nat64;
+};
+
+type create_canister_args = record {
     settings : opt canister_settings;
     sender_canister_version : opt nat64;
-  }) -> (record {canister_id : canister_id});
-  update_settings : (record {
+};
+
+type create_canister_result = record {
+    canister_id : canister_id;
+};
+
+type update_settings_args = record {
     canister_id : principal;
     settings : canister_settings;
     sender_canister_version : opt nat64;
-  }) -> ();
-  install_code : (record {
-    mode : variant {install; reinstall; upgrade};
+};
+
+type upload_chunk_args = record {
+    canister_id : principal;
+    chunk : blob;
+};
+
+type clear_chunk_store_args = record {
+    canister_id : canister_id;
+};
+
+type stored_chunks_args = record {
+    canister_id : canister_id;
+};
+
+type canister_install_mode = variant {
+    install;
+    reinstall;
+    upgrade : opt record {
+        skip_pre_upgrade : opt bool;
+        wasm_memory_persistence : opt variant {
+            keep;
+            replace;
+        };
+    };
+};
+
+type install_code_args = record {
+    mode : canister_install_mode;
     canister_id : canister_id;
     wasm_module : wasm_module;
     arg : blob;
     sender_canister_version : opt nat64;
-  }) -> ();
-  uninstall_code : (record {
+};
+
+type install_chunked_code_args = record {
+    mode : canister_install_mode;
+    target_canister : canister_id;
+    store_canister : opt canister_id;
+    chunk_hashes_list : vec chunk_hash;
+    wasm_module_hash : blob;
+    arg : blob;
+    sender_canister_version : opt nat64;
+};
+
+type uninstall_code_args = record {
     canister_id : canister_id;
     sender_canister_version : opt nat64;
-  }) -> ();
-  start_canister : (record {canister_id : canister_id}) -> ();
-  stop_canister : (record {canister_id : canister_id}) -> ();
-  canister_status : (record {canister_id : canister_id}) -> (record {
-      status : variant { running; stopping; stopped };
-      settings: definite_canister_settings;
-      module_hash: opt blob;
-      memory_size: nat;
-      cycles: nat;
-      idle_cycles_burned_per_day: nat;
-  });
-  canister_info : (record {
-      canister_id : canister_id;
-      num_requested_changes : opt nat64;
-  }) -> (record {
-      total_num_changes : nat64;
-      recent_changes : vec change;
-      module_hash : opt blob;
-      controllers : vec principal;
-  });
-  delete_canister : (record {canister_id : canister_id}) -> ();
-  deposit_cycles : (record {canister_id : canister_id}) -> ();
-  raw_rand : () -> (blob);
-  http_request : (record {
+};
+
+type start_canister_args = record {
+    canister_id : canister_id;
+};
+
+type stop_canister_args = record {
+    canister_id : canister_id;
+};
+
+type canister_status_args = record {
+    canister_id : canister_id;
+};
+
+type canister_status_result = record {
+    status : variant { running; stopping; stopped };
+    settings : definite_canister_settings;
+    module_hash : opt blob;
+    memory_size : nat;
+    cycles : nat;
+    reserved_cycles : nat;
+    idle_cycles_burned_per_day : nat;
+    query_stats: record {
+        num_calls_total: nat;
+        num_instructions_total: nat;
+        request_payload_bytes_total: nat;
+        response_payload_bytes_total: nat;
+    };
+};
+
+type canister_info_args = record {
+    canister_id : canister_id;
+    num_requested_changes : opt nat64;
+};
+
+type canister_info_result = record {
+    total_num_changes : nat64;
+    recent_changes : vec change;
+    module_hash : opt blob;
+    controllers : vec principal;
+};
+
+type delete_canister_args = record {
+    canister_id : canister_id;
+};
+
+type deposit_cycles_args = record {
+    canister_id : canister_id;
+};
+
+type http_request_args = record {
     url : text;
-    max_response_bytes: opt nat64;
+    max_response_bytes : opt nat64;
     method : variant { get; head; post };
-    headers: vec http_header;
+    headers : vec http_header;
     body : opt blob;
     transform : opt record {
-      function : func (record {response : http_response; context : blob}) -> (http_response) query;
-      context : blob
+        function : func(record { response : http_request_result; context : blob }) -> (http_request_result) query;
+        context : blob;
     };
-  }) -> (http_response);
+};
 
-  // Threshold ECDSA signature
-  ecdsa_public_key : (record {
+type ecdsa_public_key_args = record {
     canister_id : opt canister_id;
     derivation_path : vec blob;
-    key_id : record { curve: ecdsa_curve; name: text };
-  }) -> (record { public_key : blob; chain_code : blob; });
-  sign_with_ecdsa : (record {
+    key_id : record { curve : ecdsa_curve; name : text };
+};
+
+type ecdsa_public_key_result = record {
+    public_key : blob;
+    chain_code : blob;
+};
+
+type sign_with_ecdsa_args = record {
     message_hash : blob;
     derivation_path : vec blob;
-    key_id : record { curve: ecdsa_curve; name: text };
-  }) -> (record { signature : blob });
+    key_id : record { curve : ecdsa_curve; name : text };
+};
 
-  // bitcoin interface
-  bitcoin_get_balance: (get_balance_request) -> (satoshi);
-  bitcoin_get_utxos: (get_utxos_request) -> (get_utxos_response);
-  bitcoin_send_transaction: (send_transaction_request) -> ();
-  bitcoin_get_current_fee_percentiles: (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+type sign_with_ecdsa_result = record {
+    signature : blob;
+};
 
-  // provisional interfaces for the pre-ledger world
-  provisional_create_canister_with_cycles : (record {
-    amount: opt nat;
+type node_metrics_history_args = record {
+    subnet_id : principal;
+    start_at_timestamp_nanos : nat64;
+};
+
+type node_metrics_history_result = vec record {
+    timestamp_nanos : nat64;
+    node_metrics : vec node_metrics;
+};
+
+type provisional_create_canister_with_cycles_args = record {
+    amount : opt nat;
     settings : opt canister_settings;
-    specified_id: opt canister_id;
-  }) -> (record {canister_id : canister_id});
-  provisional_top_up_canister :
-    (record { canister_id: canister_id; amount: nat }) -> ();
-}
+    specified_id : opt canister_id;
+    sender_canister_version : opt nat64;
+};
+
+type provisional_create_canister_with_cycles_result = record {
+    canister_id : canister_id;
+};
+
+type provisional_top_up_canister_args = record {
+    canister_id : canister_id;
+    amount : nat;
+};
+
+type raw_rand_result = blob;
+
+type stored_chunks_result = vec chunk_hash;
+
+type upload_chunk_result = chunk_hash;
+
+type bitcoin_get_balance_result = satoshi;
+
+type bitcoin_get_balance_query_result = satoshi;
+
+type bitcoin_get_current_fee_percentiles_result = vec millisatoshi_per_byte;
+
+type fetch_canister_logs_args = record {
+    canister_id : canister_id;
+};
+
+type canister_log_record = record {
+    idx: nat64;
+    timestamp_nanos: nat64;
+    content: blob;
+};
+
+type fetch_canister_logs_result = record {
+    canister_log_records: vec canister_log_record;
+};
+
+service ic : {
+    create_canister : (create_canister_args) -> (create_canister_result);
+    update_settings : (update_settings_args) -> ();
+    upload_chunk : (upload_chunk_args) -> (upload_chunk_result);
+    clear_chunk_store : (clear_chunk_store_args) -> ();
+    stored_chunks : (stored_chunks_args) -> (stored_chunks_result);
+    install_code : (install_code_args) -> ();
+    install_chunked_code : (install_chunked_code_args) -> ();
+    uninstall_code : (uninstall_code_args) -> ();
+    start_canister : (start_canister_args) -> ();
+    stop_canister : (stop_canister_args) -> ();
+    canister_status : (canister_status_args) -> (canister_status_result);
+    canister_info : (canister_info_args) -> (canister_info_result);
+    delete_canister : (delete_canister_args) -> ();
+    deposit_cycles : (deposit_cycles_args) -> ();
+    raw_rand : () -> (raw_rand_result);
+    http_request : (http_request_args) -> (http_request_result);
+
+    // Threshold ECDSA signature
+    ecdsa_public_key : (ecdsa_public_key_args) -> (ecdsa_public_key_result);
+    sign_with_ecdsa : (sign_with_ecdsa_args) -> (sign_with_ecdsa_result);
+
+    // bitcoin interface
+    bitcoin_get_balance : (bitcoin_get_balance_args) -> (bitcoin_get_balance_result);
+    bitcoin_get_balance_query : (bitcoin_get_balance_query_args) -> (bitcoin_get_balance_query_result) query;
+    bitcoin_get_utxos : (bitcoin_get_utxos_args) -> (bitcoin_get_utxos_result);
+    bitcoin_get_utxos_query : (bitcoin_get_utxos_query_args) -> (bitcoin_get_utxos_query_result) query;
+    bitcoin_send_transaction : (bitcoin_send_transaction_args) -> ();
+    bitcoin_get_current_fee_percentiles : (bitcoin_get_current_fee_percentiles_args) -> (bitcoin_get_current_fee_percentiles_result);
+
+    // metrics interface
+    node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
+
+    // provisional interfaces for the pre-ledger world
+    provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);
+    provisional_top_up_canister : (provisional_top_up_canister_args) -> ();
+
+    // canister logging
+    fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
+};

--- a/src/ledger.did
+++ b/src/ledger.did
@@ -112,6 +112,7 @@ type Operation = variant {
         to : AccountIdentifier;
         amount : Tokens;
         fee : Tokens;
+        spender : opt vec nat8;
     };
     Approve : record {
         from : AccountIdentifier;
@@ -121,13 +122,7 @@ type Operation = variant {
         allowance: Tokens;
         fee : Tokens;
         expires_at : opt TimeStamp;
-    };
-    TransferFrom : record {
-        from : AccountIdentifier;
-        to : AccountIdentifier;
-        spender : AccountIdentifier;
-        amount : Tokens;
-        fee : Tokens;
+        expected_allowance : opt Tokens;
     };
 };
 
@@ -266,10 +261,12 @@ type Duration = record {
 type ArchiveOptions = record {
     trigger_threshold : nat64;
     num_blocks_to_archive : nat64;
-    node_max_memory_size_bytes: opt nat64;
-    max_message_size_bytes: opt nat64;
-    controller_id: principal;
-    cycles_for_archive_creation: opt nat64;
+    node_max_memory_size_bytes : opt nat64;
+    max_message_size_bytes : opt nat64;
+    controller_id : principal;
+    more_controller_ids: opt vec principal;
+    cycles_for_archive_creation : opt nat64;
+    max_transactions_per_response : opt nat64;
 };
 
 // Account identifier encoded as a 64-byte ASCII hex string.
@@ -368,10 +365,10 @@ type ApproveArgs = record {
     spender : Account;
     amount : Icrc1Tokens;
     expected_allowance : opt Icrc1Tokens;
-    expires_at : opt TimeStamp;
+    expires_at : opt Icrc1Timestamp;
     fee : opt Icrc1Tokens;
     memo : opt blob;
-    created_at_time: opt TimeStamp;
+    created_at_time: opt Icrc1Timestamp;
 };
 
 type ApproveError = variant {
@@ -398,7 +395,91 @@ type AllowanceArgs = record {
 
 type Allowance = record {
     allowance : Icrc1Tokens;
-    expires_at : opt TimeStamp;
+    expires_at : opt Icrc1Timestamp;
+};
+
+type TransferFromArgs = record {
+    spender_subaccount : opt SubAccount;
+    from : Account;
+    to : Account;
+    amount : Icrc1Tokens;
+    fee : opt Icrc1Tokens;
+    memo : opt blob;
+    created_at_time: opt Icrc1Timestamp;
+};
+
+type TransferFromResult = variant {
+    Ok : Icrc1BlockIndex;
+    Err : TransferFromError;
+};
+
+type TransferFromError = variant {
+    BadFee : record { expected_fee : Icrc1Tokens };
+    BadBurn : record { min_burn_amount : Icrc1Tokens };
+    InsufficientFunds : record { balance : Icrc1Tokens };
+    InsufficientAllowance : record { allowance : Icrc1Tokens };
+    TooOld;
+    CreatedInFuture : record { ledger_time : Icrc1Timestamp };
+    Duplicate : record { duplicate_of : Icrc1BlockIndex };
+    TemporarilyUnavailable;
+    GenericError : record { error_code : nat; message : text };
+};
+
+type icrc21_consent_message_metadata = record {
+    language: text;
+    utc_offset_minutes: opt int16;
+};
+
+type icrc21_consent_message_spec = record {
+    metadata: icrc21_consent_message_metadata;
+    device_spec: opt variant {
+        GenericDisplay;
+        LineDisplay: record {
+            characters_per_line: nat16;
+            lines_per_page: nat16;
+        };
+    };
+};
+
+type icrc21_consent_message_request = record {
+    method: text;
+    arg: blob;
+    user_preferences: icrc21_consent_message_spec;
+};
+
+type icrc21_consent_message = variant {
+    GenericDisplayMessage: text;
+    LineDisplayMessage: record {
+        pages: vec record {
+            lines: vec text;
+        };
+    };
+};
+
+type icrc21_consent_info = record {
+    consent_message: icrc21_consent_message;
+    metadata: icrc21_consent_message_metadata;
+};
+
+type icrc21_error_info = record {
+    description: text;
+};
+
+type icrc21_error = variant {
+    UnsupportedCanisterCall: icrc21_error_info;
+    ConsentMessageUnavailable: icrc21_error_info;
+    InsufficientPayment: icrc21_error_info;
+
+    // Any error not covered by the above variants.
+    GenericError: record {
+       error_code: nat;
+       description: text;
+   };
+};
+
+type icrc21_consent_message_response = variant {
+    Ok: icrc21_consent_info;
+    Err: icrc21_error;
 };
 
 service: (LedgerCanisterPayload) -> {
@@ -409,6 +490,9 @@ service: (LedgerCanisterPayload) -> {
 
     // Returns the amount of Tokens on the specified account.
     account_balance : (AccountBalanceArgs) -> (Tokens) query;
+
+    // Returns the account identifier for the given Principal and subaccount.
+    account_identifier : (Account) -> (AccountIdentifier) query;
 
     // Returns the current transfer_fee.
     transfer_fee : (TransferFeeArg) -> (TransferFee) query;
@@ -448,4 +532,8 @@ service: (LedgerCanisterPayload) -> {
     icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
     icrc2_approve : (ApproveArgs) -> (ApproveResult);
     icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
+    icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
+
+    icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
+    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
         .history_ignore_space(true)
         .completion_type(CompletionType::List)
         .build();
-    let h = MyHelper::new(agent, url.to_string(), offline);
+    let h = MyHelper::new(agent, url.to_string(), offline, opts.verbose);
     if let Some(file) = opts.send {
         use crate::offline::{send_messages, Messages};
         let json = std::fs::read_to_string(file)?;
@@ -154,7 +154,7 @@ struct Opts {
     /// Send signed messages
     send: Option<String>,
     #[clap(short, long)]
-    /// Run script in verbose mode
+    /// Run script in verbose mode. Non-verbose mode will only output text values.
     verbose: bool,
     #[clap(last = true)]
     /// Extra arguments passed to __main function when running a script

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
         }
     }
     if enter_repl {
+        rl.helper_mut().unwrap().verbose = true;
         let mut count = 1;
         loop {
             let identity = &rl.helper().unwrap().current_identity;

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,13 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
         let cmd = Command::Load(file);
         let helper = rl.helper_mut().unwrap();
         cmd.run(helper)?;
+        if helper.func_env.0.contains_key("__main") {
+            let mut args = Vec::new();
+            for arg in opts.extra_args {
+                args.push(candid_parser::parse_idl_value(&arg)?);
+            }
+            exp::apply_func(helper, "__main", args)?;
+        }
     }
     if enter_repl {
         let mut count = 1;
@@ -148,6 +155,9 @@ struct Opts {
     #[clap(short, long, conflicts_with("script"), conflicts_with("offline"))]
     /// Send signed messages
     send: Option<String>,
+    #[clap(last = true)]
+    /// Extra arguments passed to __main function when running a script
+    extra_args: Vec<String>,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use ic_agent::agent::http_transport::ReqwestTransport;
 use ic_agent::Agent;
 use rustyline::error::ReadlineError;
 use rustyline::CompletionType;
@@ -54,9 +53,7 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
         url => url,
     };
     println!("Ping {url}...");
-    let agent = Agent::builder()
-        .with_transport(ReqwestTransport::create(url)?)
-        .build()?;
+    let agent = Agent::builder().with_url(url).build()?;
 
     println!("Canister REPL");
     let config = rustyline::Config::builder()
@@ -156,6 +153,9 @@ struct Opts {
     #[clap(short, long, conflicts_with("script"), conflicts_with("offline"))]
     /// Send signed messages
     send: Option<String>,
+    #[clap(short, long)]
+    /// Run script in verbose mode
+    verbose: bool,
     #[clap(last = true)]
     /// Extra arguments passed to __main function when running a script
     extra_args: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,9 +70,7 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
     }
     let mut rl = rustyline::Editor::with_config(config)?;
     rl.set_helper(Some(h));
-    if rl.load_history("./.history").is_err() {
-        eprintln!("No history found");
-    }
+    let _ = rl.load_history("./.history");
     if let Some(file) = opts.config {
         let config = std::fs::read_to_string(file)?;
         rl.helper_mut().unwrap().config = config.parse::<candid_parser::configs::Configs>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,14 @@ fn repl(opts: Opts) -> anyhow::Result<()> {
 
     let enter_repl = opts.script.is_none() || opts.interactive;
     if let Some(file) = opts.script {
-        let cmd = Command::Load(file);
+        let cmd = Command::Load(exp::Exp::Text(file));
         let helper = rl.helper_mut().unwrap();
         cmd.run(helper)?;
         if helper.func_env.0.contains_key("__main") {
             let mut args = Vec::new();
             for arg in opts.extra_args {
-                args.push(candid_parser::parse_idl_value(&arg)?);
+                let v = candid_parser::parse_idl_value(&arg).unwrap_or(candid::IDLValue::Text(arg));
+                args.push(v);
             }
             exp::apply_func(helper, "__main", args)?;
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -77,8 +77,6 @@ pub enum Token {
     Assert,
     #[token("identity")]
     Identity,
-    #[token("export")]
-    Export,
     #[token("load")]
     Load,
     #[token("function")]


### PR DESCRIPTION
* Change `export` command to `export` function
* `load 'a.sh?'` silence the error if `a.sh` doesn't exist. `load` can take an expression instead of fixed text.
* add `__main` function that can take arguments from CLI
* `exec` function
* `replica_url` function
* add `registry` and `cycles_ledger` canister id
* verbose mode `-v`. Without verbose mode, only output the result if the return type is text.