### PR TITLE
fix: vendored openssl when cross build arm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "lalrpop-util",
  "libflate",
  "logos",
+ "openssl",
  "pem",
  "pretty",
  "pretty_assertions",
@@ -2123,6 +2124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2140,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ ic-agent = "0.39"
 ic-identity-hsm = "0.39"
 ic-transport-types = "0.39"
 ic-wasm = { version = "0.9", default-features = false }
-inferno = { version = "0.11", default-features = false, features = ["multithreaded", "nameattr"] }
+inferno = { version = "0.11", default-features = false, features = [
+    "multithreaded",
+    "nameattr",
+] }
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
 rand = "0.8"
@@ -50,3 +53,7 @@ base64 = "0.21"
 futures = "0.3.30"
 reqwest = "0.12.9"
 serde_with = { version = "3.11.0", features = ["base64"] }
+
+# When cross-compiling for ARM, we need to use a vendored version of OpenSSL
+[target.arm-unknown-linux-gnueabihf.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
The v0.7.7 release attempt failed:
https://github.com/dfinity/ic-repl/actions/runs/12712647778/job/35438701793#step:6:312

Running this build command on Ubuntu should work now.
```
cross build --target arm-unknown-linux-gnueabihf --release --locked
```