### PR TITLE
feat: Better support for subaccounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ ic-repl [--replica [local|ic|url] | --offline [--format [json|ascii|png]]] --con
 Similar to most shell languages, functions in ic-repl is dynamically scoped and untyped.
 
 We also provide some built-in functions:
-* `account(principal)`: convert principal to account id.
+* `account(principal)`: convert principal to account id (blob).
+* `account(principal, blob)`: convert principal and subaccount (blob) to account id (blob).
+* `subaccount(principal)`: convert principal to subaccount (blob).
 * `neuron_account(principal, nonce)`: convert (principal, nonce) to account in the governance canister.
 * `file(path)`: load external file as a blob value.
 * `gzip(blob)`: gzip a blob value.

--- a/examples/func.sh
+++ b/examples/func.sh
@@ -48,6 +48,11 @@ assert eq((service "aaaaa-aa" : principal), principal "aaaaa-aa") == true;
 assert (func "aaaaa-aa".test : service {}) == service "aaaaa-aa";
 assert (principal "aaaaa-aa" : service {}) == service "aaaaa-aa";
 
+assert account(principal "aaaaa-aa") == blob "\2d\0e\89\7f\7e\86\2d\2b\57\d9\bc\9e\a5\c6\5f\9a\24\ac\6c\07\45\75\f4\78\98\31\4b\8d\6c\b0\92\9d";
+assert subaccount(principal "aaaaa-aa") == blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00";
+assert account(principal "aaaaa-aa", subaccount(principal "aaaaa-aa")) == blob "\2d\0e\89\7f\7e\86\2d\2b\57\d9\bc\9e\a5\c6\5f\9a\24\ac\6c\07\45\75\f4\78\98\31\4b\8d\6c\b0\92\9d";
+assert account(principal "aaaaa-aa", subaccount(principal "2vxsx-fae")) == blob "\ad\2f\2a\2f\19\a4\ef\fd\a2\af\d4\44\66\12\37\cf\77\4f\44\95\df\68\bd\67\1f\b4\16\0a\ca\5b\13\41";
+
 assert ("this is a text" : blob) == blob "this is a text";
 assert (blob "this is a blob" : text) == "this is a blob";
 

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -164,6 +164,18 @@ impl Exp {
                             let account = AccountIdentifier::new(*principal, None);
                             IDLValue::Blob(account.to_vec())
                         }
+                        [IDLValue::Principal(principal), IDLValue::Blob(subaccount)] => {
+                            let subaccount = Subaccount::try_from(subaccount.as_slice())?;
+                            let account = AccountIdentifier::new(*principal, Some(subaccount));
+                            IDLValue::Blob(account.to_vec())
+                        }
+                        _ => return Err(anyhow!("account expects principal")),
+                    },
+                    "subaccount" => match args.as_slice() {
+                        [IDLValue::Principal(principal)] => {
+                            let subaccount = Subaccount::from(principal);
+                            IDLValue::Blob(subaccount.to_vec())
+                        }
                         _ => return Err(anyhow!("account expects principal")),
                     },
                     "neuron_account" => match args.as_slice() {


### PR DESCRIPTION
Add the following built-in function support:

- `account(principal, blob)` converts principal and subaccount (blob) to account id (blob), used by the ICP ledger.
- `subaccount(principal)` converts principal to subaccount (blob), which is what the CMC canister expects.